### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,9 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<jvmArguments>--add-opens java.base/java.nio.charset=ALL-UNNAMED</jvmArguments>
+				</configuration>
 			</plugin>
 			<plugin>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Add jvmArguments to the spring-boot-maven-plugin

Works round the: 

> java.lang.reflect.InaccessibleObjectException: Unable to make protected java.nio.charset.Charset(java.lang.String,java.lang.String[])

Issue when calling: `mvn spring-boot:run`