### PR TITLE
Updated to use autoconfiguration of the MongoTemplate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,10 @@
 			<artifactId>spring-ai-openai-spring-boot-starter</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-spring-boot-autoconfigure</artifactId>
+		</dependency>
+		<dependency>
 		    <groupId>org.springframework.ai</groupId>
 		    <artifactId>spring-ai-mongodb-atlas-store</artifactId>
 		</dependency>
@@ -34,7 +38,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-		
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
@@ -60,23 +63,9 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
 			<plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-                <fork>true</fork>
-                <compilerArgs>
-                    <arg>--add-opens</arg>
-                    <arg>java.base/java.nio.charset=ALL-UNNAMED</arg>
-                </compilerArgs>
-            </configuration>
-        </plugin>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-                <argLine>--add-opens java.base/java.nio.charset=ALL-UNNAMED</argLine>
-            </configuration>
-        </plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 	<repositories>

--- a/src/main/java/com/mongodb/springai_mongodb/config/MongodbConfig.java
+++ b/src/main/java/com/mongodb/springai_mongodb/config/MongodbConfig.java
@@ -1,6 +1,5 @@
 package com.mongodb.springai_mongodb.config;
 
-import org.bson.Document;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.openai.OpenAiEmbeddingModel;
 import org.springframework.ai.openai.api.OpenAiApi;
@@ -12,12 +11,6 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.MongoTemplate;
-
-import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoClients;
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoCursor;
-import com.mongodb.client.MongoDatabase;
 
 @Configuration
 @SpringBootConfiguration
@@ -41,37 +34,8 @@ public class MongodbConfig {
 
     @Bean
     public VectorStore mongodbVectorStore(MongoTemplate mongoTemplate, EmbeddingModel embeddingModel) {
-        boolean indexExists = false;
-
-        try (MongoClient mongoClient = MongoClients.create(mongoUri)) {
-            MongoDatabase database = mongoClient.getDatabase(databaseName);
-            MongoCollection<Document> collection = database.getCollection(collectionName);
-
-            // Retrieve search indexes
-            try (MongoCursor<Document> resultsCursor = collection.listSearchIndexes()
-                .iterator()) {
-                while (resultsCursor.hasNext()) {
-                    Document indexDocument = resultsCursor.next();
-                    if (indexName.equals(indexDocument.getString("name"))) {
-                        indexExists = true;
-                        break;
-                    }
-                }
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
-        // Set initializeSchema based on whether the index exists
-        boolean initializeSchema = !indexExists;
-
-        return new MongoDBAtlasVectorStore(mongoTemplate, embeddingModel, MongoDBAtlasVectorStore.MongoDBVectorStoreConfig.builder()
-            .build(), initializeSchema);
-    }
-
-    @Bean
-    public MongoTemplate mongoTemplate(MongoClient mongoClient) {
-        return new MongoTemplate(mongoClient, databaseName);
+        return new MongoDBAtlasVectorStore(mongoTemplate, embeddingModel,
+                MongoDBAtlasVectorStore.MongoDBVectorStoreConfig.builder().build(), true);
     }
 
     @Bean


### PR DESCRIPTION
This uses the latest (1.0.0-SNAPSHOT) fixes to auto configure the MongoTemplate with the correct converters. - Fixes the persistence issue.

Also, the latest snapshot includes a fix for the index.